### PR TITLE
Onboarding page: Get Started button alligned properly and also made r…

### DIFF
--- a/app/src/main/res/layout/activity_onboarding.xml
+++ b/app/src/main/res/layout/activity_onboarding.xml
@@ -63,18 +63,18 @@
         app:layout_constraintStart_toStartOf="parent"
         app:srcCompat="@drawable/ic_baseline_arrow_back_ios_24" />
 
+
     <Button
         android:id="@+id/button"
-        android:layout_width="334dp"
+        android:layout_width="0dp"
         android:layout_height="55dp"
-        android:layout_marginStart="40dp"
         android:layout_marginTop="16dp"
-        android:layout_marginEnd="40dp"
         android:layout_marginBottom="36dp"
         android:background="@drawable/round_button"
         android:text="@string/getStarted"
         android:textAllCaps="false"
         android:textColor="#ffffff"
+        android:layout_marginHorizontal="@dimen/dimension_40dp"
         android:textSize="18sp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"


### PR DESCRIPTION
Fixed the "Get Started" button on the onboarding screen.
Also make the Onboarding screen responsive on tab.

below is are before and after screenShots.

**Before**
![tab](https://user-images.githubusercontent.com/61974104/87091148-08120f80-c1ee-11ea-890c-79a474a68c1e.png)

**After**
![tap fixed](https://user-images.githubusercontent.com/61974104/87091255-3abc0800-c1ee-11ea-83af-415f874c9509.png)

**Before**
![started](https://user-images.githubusercontent.com/61974104/87091475-94243700-c1ee-11ea-868d-6ba5abccc689.png)

**After**
![getstarted](https://user-images.githubusercontent.com/61974104/87091533-adc57e80-c1ee-11ea-971f-6b69993dd3f8.png)
